### PR TITLE
refactor(moviepilot): 重构电影订阅插件以简化用户交互流程

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from astrbot.core.utils.session_waiter import (
 )
 from .api import MoviepilotApi
 
-@register("MoviepilotSubscribe", "4Nest", "MoviepilotQQ机器人订阅 插件", "1.1.0", "https://github.com/4Nest/astrbot_plugin_mp_sub")
+@register("MoviepilotSubscribe", "4Nest", "MoviepilotQQ机器人订阅 插件", "1.1.1", "https://github.com/4Nest/astrbot_plugin_mp_sub")
 class MyPlugin(Star):
     def __init__(self, context: Context, config: dict):
         super().__init__(context)

--- a/main.py
+++ b/main.py
@@ -1,9 +1,15 @@
 from astrbot.api.event import filter, AstrMessageEvent, MessageEventResult
 from astrbot.api.star import Context, Star, register
 from astrbot.api import logger
+import time
+import astrbot.api.message_components as Comp
+from astrbot.core.utils.session_waiter import (
+    session_waiter,
+    SessionController,
+)
 from .api import MoviepilotApi
 
-@register("MoviepilotSubscribe", "4Nest", "MoviepilotQQ机器人订阅 插件", "1.0.0", "https://github.com/4Nest/astrbot_plugin_mp_sub")
+@register("MoviepilotSubscribe", "4Nest", "MoviepilotQQ机器人订阅 插件", "1.1.0", "https://github.com/4Nest/astrbot_plugin_mp_sub")
 class MyPlugin(Star):
     def __init__(self, context: Context, config: dict):
         super().__init__(context)
@@ -19,78 +25,131 @@ class MyPlugin(Star):
         if movies:
             movie_list = "\n".join([f"{i + 1}. {movie['title']} ({movie['year']})" for i, movie in enumerate(movies)])
             print(movie_list)
-            media_list = "\n查询到的影片如下\n@机器人 /select 0 退出选择\n请@机器人 /select 序号 进行订阅：\n" + movie_list
+            media_list = "\n查询到的影片如下\n请直接回复序号进行订阅（回复0退出选择）：\n" + movie_list
             yield event.plain_result(media_list)
-            user_id = event.get_sender_id()  # 获取用户ID
-            self.state[user_id] = {"movies": movies}  # 保存用户状态
+            
+            # 使用会话控制器等待用户回复
+            @session_waiter(timeout=60, record_history_chains=False)
+            async def movie_selection_waiter(controller: SessionController, event: AstrMessageEvent):
+                try:
+                    user_input = event.message_str.strip()
+                    user_id = event.get_sender_id()
+                    
+                    # 检查用户是否在等待选择季度
+                    user_state = self.state.get(user_id, {})
+                    if user_state.get("waiting_for") == "season":
+                        # 用户正在选择季度
+                        try:
+                            season_number = int(user_input)
+                            selected_movie = user_state["selected_movie"]
+                            seasons = user_state["seasons"]
+                            
+                            # 验证季度是否有效
+                            valid_season = False
+                            for season in seasons:
+                                if season['season_number'] == season_number:
+                                    valid_season = True
+                                    break
+                            
+                            if valid_season:
+                                # 订阅电视剧的指定季度
+                                success = await self.api.subscribe_series(selected_movie, season_number)
+                                message_result = event.make_result()
+                                if success:
+                                    message_result.chain = [Comp.Plain(f"\n订阅类型：{selected_movie['type']}\n订阅影片：{selected_movie['title']} ({selected_movie['year']})\n订阅第 {season_number} 季成功！")]
+                                else:
+                                    message_result.chain = [Comp.Plain("订阅失败。")]
+                                await event.send(message_result)
+                                # 清除状态
+                                self.state.pop(user_id, None)
+                                controller.stop()
+                            else:
+                                message_result = event.make_result()
+                                message_result.chain = [Comp.Plain("无效的季数，请重新输入。")]
+                                await event.send(message_result)
+                                controller.keep(timeout=60, reset_timeout=True)
+                        except ValueError:
+                            message_result = event.make_result()
+                            message_result.chain = [Comp.Plain("请输入一个有效的季数。")]
+                            await event.send(message_result)
+                            controller.keep(timeout=60, reset_timeout=True)
+                        return
+                    
+                    # 处理电影选择
+                    try:
+                        index = int(user_input) - 1
+                        
+                        if index == -1:  # 用户输入0
+                            message_result = event.make_result()
+                            message_result.chain = [Comp.Plain("操作已取消。")]
+                            await event.send(message_result)
+                            controller.stop()
+                            return
+                            
+                        if 0 <= index < len(movies):
+                            selected_movie = movies[index]
+                            if selected_movie['type'] == "电视剧":
+                                # 如果是电视剧，获取所有季数
+                                seasons = await self.api.list_all_seasons(selected_movie['tmdb_id'])
+                                if seasons:
+                                    season_list = "\n".join(
+                                        [f"第 {season['season_number']} 季 {season['name']}" for season in seasons])
+                                    season_list = "\n查询到的季如下\n请直接回复季数进行选择：\n" + season_list
+                                    
+                                    message_result = event.make_result()
+                                    message_result.chain = [Comp.Plain(season_list)]
+                                    await event.send(message_result)
+                                    
+                                    # 继续等待用户选择季数
+                                    controller.keep(timeout=60, reset_timeout=True)
+                                    
+                                    # 更新状态
+                                    self.state[user_id] = {
+                                        "selected_movie": selected_movie,
+                                        "seasons": seasons,
+                                        "waiting_for": "season"
+                                    }
+                                else:
+                                    message_result = event.make_result()
+                                    message_result.chain = [Comp.Plain("没有找到可用的季数。")]
+                                    await event.send(message_result)
+                                    controller.stop()
+                            else:
+                                # 如果是电影，直接订阅
+                                success = await self.api.subscribe_movie(selected_movie)
+                                message_result = event.make_result()
+                                if success:
+                                    message_result.chain = [Comp.Plain(f"\n订阅类型：{selected_movie['type']}\n订阅影片：{selected_movie['title']} ({selected_movie['year']})\n订阅成功！")]
+                                else:
+                                    message_result.chain = [Comp.Plain("订阅失败。")]
+                                await event.send(message_result)
+                                controller.stop()
+                        else:
+                            message_result = event.make_result()
+                            message_result.chain = [Comp.Plain("无效的序号，请重新输入。")]
+                            await event.send(message_result)
+                            controller.keep(timeout=60, reset_timeout=True)
+                    except ValueError:
+                        message_result = event.make_result()
+                        message_result.chain = [Comp.Plain("请输入一个数字。")]
+                        await event.send(message_result)
+                        controller.keep(timeout=60, reset_timeout=True)
+                except Exception as e:
+                    logger.error(f"处理用户输入时出错: {e}")
+                    message_result = event.make_result()
+                    message_result.chain = [Comp.Plain(f"处理输入时出错: {str(e)}")]
+                    await event.send(message_result)
+                    controller.stop()
+            
+            try:
+                await movie_selection_waiter(event)
+            except Exception as e:
+                logger.error(f"Movie selection error: {e}")
+                yield event.plain_result(f"发生错误：{str(e)}")
+            finally:
+                event.stop_event()
         else:
             yield event.plain_result("没有查询到影片，请检查名字。")
-
-    @filter.command("select")
-    async def select(self, event: AstrMessageEvent, message: str):
-        '''选择影片'''
-        user_id = event.get_sender_id()  # 获取用户ID
-        user_state = self.state.get(user_id)
-        if user_state and "movies" in user_state:
-            try:
-                index = int(message) - 1
-                if index == -1:  # 用户输入0
-                    yield event.plain_result("操作已取消。")
-                    del self.state[user_id]  # 清除用户状态
-                    return
-                if 0 <= index < len(user_state["movies"]):
-                    selected_movie = user_state["movies"][index]
-                    if selected_movie['type'] == "电视剧":
-                        # 如果是电视剧，获取所有季数
-                        seasons = await self.api.list_all_seasons(selected_movie['tmdb_id'])
-                        if seasons:
-                            season_list = "\n".join(
-                                [f"第 {season['season_number']} 季 {season['name']}" for season in seasons])
-                            season_list = "\n查询到的季如下\n请@机器人 /season 序号 进行选择：\n请选择季数：\n" + season_list
-                            yield event.plain_result(season_list)
-                            user_state["selected_movie"] = selected_movie
-                            user_state["seasons"] = seasons
-                        else:
-                            yield event.plain_result("没有找到可用的季数。")
-                    else:
-                        # 如果是电影，直接订阅
-                        success = await self.api.subscribe_movie(selected_movie)
-                        if success:
-                            yield event.plain_result(f"\n订阅类型：{selected_movie['type']}\n订阅影片：{selected_movie['title']} ({selected_movie['year']})\n订阅成功！")
-                            del self.state[user_id]  # 清除用户状态
-                        else:
-                            yield event.plain_result("订阅失败。")
-                else:
-                    yield event.plain_result("无效的序号，请重新输入。")
-            except ValueError:
-                yield event.plain_result("请输入一个数字。")
-        else:
-            yield event.plain_result("请先使用 /sub 命令搜索影片。")
-
-    @filter.command("season")
-    async def season(self, event: AstrMessageEvent, message: str):
-        '''选择季度'''
-        user_id = event.get_sender_id()  # 获取用户ID
-        user_state = self.state.get(user_id)
-        if user_state and "selected_movie" in user_state and "seasons" in user_state:
-            try:
-                season_number = int(message)
-                seasons = user_state["seasons"]
-                selected_movie = user_state["selected_movie"]
-                for season in seasons:
-                    if season['season_number'] == season_number:
-                        success = await self.api.subscribe_series(selected_movie, season_number)
-                        if success:
-                            yield event.plain_result(f"\n订阅类型：{selected_movie['type']}\n订阅影片：{selected_movie['title']} ({selected_movie['year']})\n订阅第 {season_number} 季成功！")
-                            del self.state[user_id]  # 清除用户状态
-                        else:
-                            yield event.plain_result("订阅失败。")
-                        return
-                yield event.plain_result("无效的季数，请重新输入。")
-            except ValueError:
-                yield event.plain_result("请输入一个数字。")
-        else:
-            yield event.plain_result("请先使用 /sub 和 /select 命令选择电视剧和季数。")
 
     @filter.command("download")
     async def progress(self, event: AstrMessageEvent):

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: moviepilot_sub # 这是你的插件的唯一识别名。
 desc: Moviepilot订阅 # 插件简短描述
 help:  # 插件的帮助信息
-version: v1.1 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v1.1.1 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: 4Nest # 作者
 repo: https://github.com/4Nest/astrbot_plugin_mp_sub # 插件的仓库地址


### PR DESCRIPTION
refactor(moviepilot): 重构电影订阅插件以简化用户交互流程

重构了电影订阅插件的用户交互逻辑，使用会话控制器 session_waiter 替代原有的命令式交互，简化了用户操作流程。用户现在可以直接回复序号进行订阅，而无需使用特定命令。同时，插件版本更新至 1.1.1。